### PR TITLE
Removed Unstable_injector and phasefield from Cassiopeia Pirate Fighter

### DIFF
--- a/data/hulls/HS_Cassiopeia_Pirate.ship
+++ b/data/hulls/HS_Cassiopeia_Pirate.ship
@@ -12,8 +12,6 @@
   "shieldRadius": 66.5,
   "viewOffset": 0,
   "builtInMods": [
-    "unstable_injector",
-    "phasefield",
     "delicate"
   ],
   "weaponSlots": [


### PR DESCRIPTION
Hello Ninja, 

I am not sure if you allow PR's from other people, I have honestly not checked. I like this mod and noticed that this fighter has both unstable_injector as well as phasefield in its mods - which causes the game to crash when you open the doctrine or custom production tab. 

This should fix this. 

Lets hope I am not missing any dependencies - because then I would make a fool of myself for making this pr 😄 


Changelog:
-Removed unstable_injector and phasefield from HS_Cassiopeia_Pirate Fighter